### PR TITLE
Add retro coffee shop illustration

### DIFF
--- a/coffee_shop.svg
+++ b/coffee_shop.svg
@@ -1,0 +1,21 @@
+<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="100%" height="100%" fill="darkslategray" />
+  <!-- Street -->
+  <rect y="250" width="400" height="50" fill="dimgray" />
+  <!-- Shop building -->
+  <rect x="90" y="150" width="220" height="100" fill="#3e2c23" stroke="black" stroke-width="2" />
+  <!-- Windows -->
+  <rect x="110" y="170" width="50" height="50" fill="#ffe4b5" opacity="0.8" />
+  <rect x="240" y="170" width="50" height="50" fill="#ffe4b5" opacity="0.8" />
+  <!-- Signboard -->
+  <rect x="150" y="120" width="100" height="40" fill="#552200" stroke="orange" stroke-width="2" />
+  <text x="200" y="145" font-size="16" text-anchor="middle" fill="orange">珈琲店</text>
+  <!-- Roof -->
+  <polygon points="80,150 200,80 320,150" fill="#2b1b12" stroke="black" stroke-width="2" />
+  <!-- Rain lines -->
+  <line x1="50" y1="160" x2="60" y2="190" stroke="lightblue" stroke-width="2" />
+  <line x1="350" y1="160" x2="340" y2="190" stroke="lightblue" stroke-width="2" />
+  <line x1="200" y1="160" x2="210" y2="190" stroke="lightblue" stroke-width="2" />
+  <line x1="250" y1="160" x2="260" y2="190" stroke="lightblue" stroke-width="2" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -80,6 +80,11 @@
       <span class="btn message">さっそく開発する</span>
     </div>
   </div>
+  <div class="coffee-shop-wrapper">
+    <div class="container">
+      <img src="coffee_shop.svg" alt="A nostalgic retro Japanese coffee shop at night with a glowing signboard, warm light from the windows, wooden frames and a rainy street." />
+    </div>
+  </div>
   <footer>
     <div class="container">
       <img src="https://prog-8.com/images/html/advanced/footer_logo.png">

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -163,6 +163,14 @@ header {
   padding-bottom: 80px;
   text-align: center;
 }
+.coffee-shop-wrapper {
+  background-color: #2f2f2f;
+  padding: 40px 0;
+  text-align: center;
+}
+.coffee-shop-wrapper img {
+  max-width: 100%;
+}
 
 .message {
   padding: 15px 40px;


### PR DESCRIPTION
## Summary
- include an SVG depicting a cozy retro coffee shop at night
- display the image in a new section on the page
- style the new section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d6553382c8324abe97adbd0b79be6